### PR TITLE
Fixes (#18833)

### DIFF
--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -792,6 +792,10 @@ class OnvifController:
             )
             return
 
+        logger.debug(
+            f"{camera_name}: Pan/tilt status: {pan_tilt_status}, Zoom status: {zoom_status}"
+        )
+
         if pan_tilt_status == "IDLE" and (zoom_status is None or zoom_status == "IDLE"):
             self.cams[camera_name]["active"] = False
             if not self.ptz_metrics[camera_name].motor_stopped.is_set():

--- a/web/src/components/overlay/detail/SearchDetailDialog.tsx
+++ b/web/src/components/overlay/detail/SearchDetailDialog.tsx
@@ -721,7 +721,7 @@ function ObjectDetailsTab({
                 ns: "objects",
               })}
               {search.sub_label && ` (${search.sub_label})`}
-              {isAdmin && (
+              {isAdmin && search.end_time && (
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <span>
@@ -1242,13 +1242,13 @@ export function VideoTab({ search }: VideoTabProps) {
     <>
       <span tabIndex={0} className="sr-only" />
       <GenericVideoPlayer source={source}>
-        {reviewItem && (
-          <div
-            className={cn(
-              "absolute top-2 z-10 flex items-center gap-2",
-              isIOS ? "right-8" : "right-2",
-            )}
-          >
+        <div
+          className={cn(
+            "absolute top-2 z-10 flex items-center gap-2",
+            isIOS ? "right-8" : "right-2",
+          )}
+        >
+          {reviewItem && (
             <Tooltip>
               <TooltipTrigger>
                 <Chip
@@ -1271,25 +1271,25 @@ export function VideoTab({ search }: VideoTabProps) {
                 </TooltipContent>
               </TooltipPortal>
             </Tooltip>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <a
-                  download
-                  href={`${baseUrl}api/${search.camera}/${clipTimeRange}/clip.mp4`}
-                >
-                  <Chip className="cursor-pointer rounded-md bg-gray-500 bg-gradient-to-br from-gray-400 to-gray-500">
-                    <FaDownload className="size-4 text-white" />
-                  </Chip>
-                </a>
-              </TooltipTrigger>
-              <TooltipPortal>
-                <TooltipContent>
-                  {t("button.download", { ns: "common" })}
-                </TooltipContent>
-              </TooltipPortal>
-            </Tooltip>
-          </div>
-        )}
+          )}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <a
+                download
+                href={`${baseUrl}api/${search.camera}/${clipTimeRange}/clip.mp4`}
+              >
+                <Chip className="cursor-pointer rounded-md bg-gray-500 bg-gradient-to-br from-gray-400 to-gray-500">
+                  <FaDownload className="size-4 text-white" />
+                </Chip>
+              </a>
+            </TooltipTrigger>
+            <TooltipPortal>
+              <TooltipContent>
+                {t("button.download", { ns: "common" })}
+              </TooltipContent>
+            </TooltipPortal>
+          </Tooltip>
+        </div>
       </GenericVideoPlayer>
     </>
   );


### PR DESCRIPTION
* Don't allow editing of sub label until object lifecycle has ended

* Update sub labels in ended review segments

When manually editing a sub label for a tracked object from the UI, any review segments containing that tracked object did not have their sub_labels and objects values altered

* simplify

* Additional onvif debug logs in get_camera_status

* Ensure that best object is only set when the snapshot is actually updated.

* Don't hide downlaod button when there is no review item

---------

## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
